### PR TITLE
Rename CLI `build` command to `init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ A tool and framework to simplify construction of Python Dash applications.
 
 * Create a project in the current working directory
 ```bash
-> dash build
+> dash init
 ```
 
 * Create project called `testproject` in specified directory
 ```bash
-> dash build testproject --location ~/projects
+> dash init testproject --location ~/projects
 ```
 
 * Add new page to current dash project in pages/ directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
 ]
 
 [project.scripts]
-dashb = "dash_builder.cli:app"
 dash = "dash_builder.cli:app"
 
 [build-system]

--- a/src/dash_builder/cli.py
+++ b/src/dash_builder/cli.py
@@ -16,7 +16,7 @@ from typing_extensions import Annotated
 from .templates import PageTemplate, ViewTemplate
 
 app: typer.Typer = typer.Typer()
-"""The `typer.Typer` applicaiton object."""
+"""The `typer.Typer` application object."""
 
 
 class Project:
@@ -229,8 +229,8 @@ class Project:
         )
 
 
-@app.command("build")
-def build(
+@app.command("init")
+def init(
     project_name: Annotated[str, typer.Argument(help="The name of the project.")] = "",
     template: Annotated[
         str, typer.Argument(help="The template to use for the project.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ from src.dash_builder.cli import app
     "project_name", ["test-project-1", "test_project_2", "testproject"]
 )
 def test_init_project_cli(runner, tmp_path, project_name):
-    app_params = ["build", project_name, "--location", str(tmp_path)]
+    app_params = ["init", project_name, "--location", str(tmp_path)]
     result = runner.invoke(app, app_params)
     project = tmp_path / project_name
     app_file = project / "app.py"


### PR DESCRIPTION
`init` is the commonly used term in this scenario. 