### PR TITLE
Merge main back to develop after release 0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           develop_branch: "develop"
           main_branch: "main"
-          merge_back_from_main: false
+          merge_back_from_main: true
           version: ${{ inputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dash-builder"
-version = "0.1.5"
+version = "0.2.0"
 description = "A tool and framework to simplify construction of Python Dash applications."
 readme = "README.md"
 authors = [{ name = "robfs", email = "robfoxsimms@gmail.com" }]


### PR DESCRIPTION
Automatic merge-back after release 0.2.0 to keep develop in sync with main.

This PR includes:
- Release 0.2.0 version bump
- Workflow configuration change for merge_back_from_main
- All changes from the release branch